### PR TITLE
Added new option, so user can manipulate HTML output

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,9 +2,37 @@
 const parse = require('rtf-parser')
 const rtfToHTML = require('./rtf-to-html.js')
 
+const htmlOptions = {
+  template: function(doc, defaults, content) {
+    return `<!DOCTYPE html>
+    <html>
+      <head>
+        <meta charset="UTF-8">
+        <style>
+        body {
+          margin-left: ${doc.marginLeft / 20}pt;
+          margin-right: ${doc.marginRight / 20}pt;
+          margin-top: ${doc.marginTop / 20}pt;
+          margin-bottom: ${doc.marginBottom /20}pt;
+          font-size: ${defaults.fontSize / 2}pt;
+          text-indent: ${defaults.firstLineIndent / 20}pt;
+        }
+        </style>
+      </head>
+      <body>
+    ${content}
+      </body>
+    </html>
+    `
+  },
+  paragraphTag: 'p',
+  lineBreaks: '\n\n'
+}
+
 module.exports = asStream
 module.exports.fromStream = fromStream
 module.exports.fromString = fromString
+module.exports.htmlOptions = htmlOptions
 
 function asStream (cb) {
   return parse(htmlifyresult(cb))
@@ -22,7 +50,7 @@ function htmlifyresult (cb) {
   return (err, doc) => {
     if (err) return cb(err)
     try {
-      return cb(null, rtfToHTML(doc))
+      return cb(null, rtfToHTML(doc, htmlOptions))
     } catch (ex) {
       return cb(ex)
     }

--- a/rtf-to-html.js
+++ b/rtf-to-html.js
@@ -1,7 +1,7 @@
 'use strict'
 module.exports = rtfToHTML
 
-function rtfToHTML (doc) {
+function rtfToHTML (doc, options) {
   const defaults = {
 //    font: doc.style.font || {name: 'Times', family: 'roman'},
     fontSize: doc.style.fontSize || 24,
@@ -14,30 +14,12 @@ function rtfToHTML (doc) {
     firstLineIndent: doc.style.firstLineIndent || 0,
     indent: 0,
     align: 'left',
-    valign: 'normal'
+    valign: 'normal',
+
+    options: options
   }
-  const content = doc.content.map(para => renderPara(para, defaults)).filter(html => html != null).join('\n\n')
-//  ${font(defaults.font)};
-  return `<!DOCTYPE html>
-<html>
-<head>
-<meta charset="UTF-8">
-<style>
-body {
-  margin-left: ${doc.marginLeft / 20}pt;
-  margin-right: ${doc.marginRight / 20}pt;
-  margin-top: ${doc.marginTop / 20}pt;
-  margin-bottom: ${doc.marginBottom /20}pt;
-  font-size: ${defaults.fontSize / 2}pt;
-  text-indent: ${defaults.firstLineIndent / 20}pt;
-}
-</style>
-</head>
-<body>
-${content}
-</body>
-</html>
-`
+  const content = doc.content.map(para => renderPara(para, defaults)).filter(html => html != null).join(options.lineBreaks)
+  return options.template(doc, defaults, content)
 }
 
 function font (ft) {
@@ -126,7 +108,8 @@ function renderPara (para, defaults) {
   for (let item of Object.keys(para.style)) {
     if (para.style[item] != null) pdefaults[item] = para.style[item]
   }
-  return `<p${style ? ' style="' + style + '"' : ''}>${tags.open}${para.content.map(span => renderSpan(span, pdefaults)).join('')}${tags.close}</p>`
+  let paragraphTag = defaults.options.paragraphTag
+  return `<${paragraphTag}${style ? ' style="' + style + '"' : ''}>${tags.open}${para.content.map(span => renderSpan(span, pdefaults)).join('')}${tags.close}</${paragraphTag}>`
 }
 
 function renderSpan (span, defaults) {


### PR DESCRIPTION
Hi,

I have added a new option object, so user can manipulate output HTML. Currently there are three options:

**template**: HTML template (function returning your HTML template, default is your original template)
**paragraphTag**: HTML tag for paragraphs (string, default is P)
**lineBreaks**: characters for line-breaks (string, default is '\n\n')

So, when you just want to output RTF content (without the rest of HTML), change P tag to DIV tag and squeeze HTML without line breaks, you can write something like:

```javascript
      rtfToHTML.htmlOptions.template = function (doc, defaults, content) { return content }
      rtfToHTML.htmlOptions.paragraphTag= 'div'
      rtfToHTML.htmlOptions.lineBreaks = ''

      rtfToHTML.fromString(this.rtf_string, (err, html) => { ... }
```

Anyway, thanks for this RTF parser!


